### PR TITLE
Use Exception not FatalError

### DIFF
--- a/src/RedisJobService.php
+++ b/src/RedisJobService.php
@@ -105,7 +105,7 @@ abstract class RedisJobService {
 	 */
 	public static function init( array $args ) : RedisJobService {
 		if ( !isset( $args['config-file'] ) || isset( $args['help'] ) ) {
-			throw new FatalError( "Usage: php RedisJobRunnerService.php\n"
+			throw new Exception( "Usage: php RedisJobRunnerService.php\n"
 				. "--config-file=[path]\n"
 				. "--help\n"
 			);


### PR DESCRIPTION
FatalError is provided by MediaWiki, nothing else here uses functions/classes provided by MediaWiki, as far as I can see. So this probably shouldn't either. I could be wrong though.