### PR TITLE
Cast $status['exitcode'] to a int

### DIFF
--- a/src/JobRunnerPipeline.php
+++ b/src/JobRunnerPipeline.php
@@ -71,7 +71,7 @@ class JobRunnerPipeline {
 			} elseif ( $status && !$status['running'] ) {
 				// $result will be an array if no exceptions happened
 				$result = json_decode( trim( $procSlot['stdout'] ), true );
-				if ( $status['exitcode'] == 0 && is_array( $result ) ) {
+				if ( (int)$status['exitcode'] == 0 && is_array( $result ) ) {
 					// If this finished early, lay off of the queue for a while
 					if ( ( $cTime - $procSlot['stime'] ) < $this->srvc->hpMaxTime/2 ) {
 						unset( $pending[$procSlot['type']][$procSlot['db']] );


### PR DESCRIPTION
Seeing  "ERROR: Runner loop 0 process in slot 0 gave status '0'", which suggests the 0 is in a string and thus not === 0 (int). So let's cast to make sure.